### PR TITLE
Added Rackspace Cloud Sites

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -133,8 +133,8 @@
   php53: 20
   php54: 10
   default: 5.3.20
-  manual_update: Yes
-  auto_update: Yes (Minor)
+  manual_update: Yes (Minor)
+  auto_update: Yes (Patch)
 
 - name: "ServerGrove"
   url: "http://servergrove.com/sharedhosting"


### PR DESCRIPTION
Pretty bad that Rackspace doesn't even support 5.5 yet. I've had to move a few sites to other hosts because of this.

To verify, these are the options when setting up a site:

![image](https://cloud.githubusercontent.com/assets/203749/5584953/e25aa24e-906a-11e4-9b39-3181d7287a02.png)
