### PR TITLE
PR to Remove Linode from TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Please ensure that hosting company names are in alphabetical order.
 As well as updating any `??` in that table, I also want to get numbers for these folks. 
 
 * Infomaniak
-* Linode
 * LiquidWeb
 * ManageWP
 * online.net


### PR DESCRIPTION
Seeing as how Linode is strictly VPS hosting and it appears to be against the idea of this initiative, I've removed it from the TODO list.  This was suggested by others as well in #29.
