### PR TITLE
Remove Linode from TODO since they're VPS only hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Please ensure that hosting company names are in alphabetical order.
 As well as updating any `??` in that data file, I also want to get numbers for these folks. 
 
 * Infomaniak
-* Linode
 * LiquidWeb
 * ManageWP
 * online.net


### PR DESCRIPTION
Seeing as how Linode is strictly VPS hosting and it appears to be against the idea of this initiative, I've removed it from the TODO list. This was suggested by others as well in #29.

P.S.  Apologies for the triple commit PR I previously submitted, must've branched from master or something.
