### PR TITLE
Add linuxpl.com

### DIFF
--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -109,6 +109,13 @@
   manual_update: "Yes"
   auto_update: "Yes"
 
+- name: Linuxpl
+  url: "http://linuxpl.com"
+  php52: 17
+  php53: 17
+  php54: 7
+  default: 5.2.17
+
 - name: Liquidweb
   url: "https://www.liquidweb.com"
   php52: ??


### PR DESCRIPTION
Adds one of the Polish hosting companies.

I'm wondering if adding some way to indicate company's ~~destination~~ location would be helpful. Maybe another variable with the country code and displaying a flag left to the company name?