### PR TITLE
Update for Google App Engine release

### DIFF
--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -84,8 +84,9 @@
 
 - name: "Google App Engine"
   url: "https://cloud.google.com/appengine/"
-  php54: 32
-  default: 5.4.32
+  php54: 35
+  php55: 20
+  default: 5.4.35
   auto_update: "Yes"
 
 - name: "Heart Internet"


### PR DESCRIPTION
App Engine now supports 5.5.20 (optionally) and default is 5.4.35