### PR TITLE
Updated version numbers for 34SP.com

### DIFF
--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -18,9 +18,10 @@
 
 - name: "34SP"
   url: "https://www.34sp.com/professional-hosting-specifications"
-  php53: ??
-  php54: ??
-  default: 5.3.??
+  php53: 29
+  php54: 38
+  php55: 24
+  default: 5.5.24
 
 - name: "A Small Orange"
   url: "https://asmallorange.com/hosting/shared/#tab-two"


### PR DESCRIPTION
New default version up to 5.5, add details of versions available as CGI for those users that require it.