### PR TITLE
Updates for names.co.uk and Register365

### DIFF
--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -197,10 +197,9 @@
 
 - name: "names.co.uk"
   url: "https://www.names.co.uk/web-hosting/"
-  php54: 42
   php55: 26
   php56: 10
-  default: 5.5.26
+  default: 5.6.10
   manual_update: "Yes (Minor)"
   auto_update: "Yes (Patch)"
 
@@ -242,10 +241,9 @@
 
 - name: "Register365"
   url: "https://www.register365.com/web-hosting/"
-  php54: 42
   php55: 26
   php56: 10
-  default: 5.5.26
+  default: 5.6.10
   manual_update: "Yes (Minor)"
   auto_update: "Yes (Patch)"
 


### PR DESCRIPTION
PHP 5.4 is no longer available for new customers, and the default version of PHP is now 5.6