### PR TITLE
Update the information for Heroku

### DIFF
--- a/_data/custom_hosts.yml
+++ b/_data/custom_hosts.yml
@@ -1,10 +1,11 @@
 - name: "Heroku"
   url: "https://devcenter.heroku.com/articles/php-support#php-runtimes"
-  php55: 20
-  php56: 4
+  php55: 28
+  php56: 12
   php70: RC1
-  default: 5.6.4
+  default: 5.6.12
   manual_update: Yes
+  auto_update: Yes
 
 - name: "Microsoft Azure Web Sites"
   url: "http://azure.microsoft.com/en-us/services/websites"


### PR DESCRIPTION
Version used were outdated, and I added the info that it supports auto-update (it selects the version based on composer constraints, so requiring ``~5.5`` will upgrade you to 5.6 automatically on next deployment once 5.6 is available for instance as it matches the constraint).
Note that the info about updates is not displayed currently for custom hosts, but the ``manual_update`` was already in the data so it makes sense to complete it.