### PR TITLE
Update info about Pagoda Box

### DIFF
--- a/_data/custom_hosts.yml
+++ b/_data/custom_hosts.yml
@@ -17,12 +17,13 @@
   manual_update: Yes
 
 - name: "Pagoda Box"
-  url: "https://pagodabox.com/"
-  php53: 23
-  php54: 14
+  url: "https://pagodabox.io/"
+  php53: ??
+  php54: ??
   php55: ??
   php56: ??
-  default: 5.??.??
+  default: 5.6.??
+  auto_update: "Yes (Patch)"
 
 - name: "ServerPilot"
   url: "https://serverpilot.io"


### PR DESCRIPTION
Pagodabox does not let the user choose the patch version. They only provide a choice between minor versions and are auto-updating patch versions based on updates in their system.
They don't expose the patch version used currently, but 5.3.23 and 5.4.14 are probably outdated given the number of upgrades since then. I haven't tried to deployed a phpinfo() on each minor version to see the patch level used today.