### PR TITLE
Add sortable table headers

### DIFF
--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -1,0 +1,1 @@
+<script src="https://cdnjs.cloudflare.com/ajax/libs/sortable/0.6.0/js/sortable.min.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
 
     {% include footer.html %}
 
+    {% include javascripts.html %}
   </body>
 
 </html>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -154,8 +154,6 @@ pre {
  * Wrapper
  */
 .wrapper {
-    max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit} * 2));
-    max-width:         calc(#{$content-width} - (#{$spacing-unit} * 2));
     margin-right: auto;
     margin-left: auto;
     padding-right: $spacing-unit;

--- a/_sass/_sortable.scss
+++ b/_sass/_sortable.scss
@@ -1,0 +1,42 @@
+table[data-sortable] {
+    $marker-color: lighten($text-color, 50);
+
+    // put cursor and disable selection of non-sotable headers
+    th:not([data-sortable="false"]) {
+      -webkit-user-select: none;
+         -moz-user-select: none;
+          -ms-user-select: none;
+           -o-user-select: none;
+              user-select: none;
+      -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+      -webkit-touch-callout: none;
+      cursor: pointer;
+    }
+
+    // sorting arrows
+    th:after {
+        content: "";
+        visibility: hidden;
+        display: inline-block;
+        vertical-align: inherit;
+        height: 0;
+        width: 0;
+        border-width: 5px;
+        border-style: solid;
+        border-color: transparent;
+        margin-right: 1px;
+        margin-left: 10px;
+        float: right;
+    }
+    th[data-sorted="true"]:after {
+      visibility: visible;
+    }
+    th[data-sorted-direction="descending"]:after {
+      border-top-color: $marker-color;
+      margin-top: 8px;
+    }
+    th[data-sorted-direction="ascending"]:after {
+      border-bottom-color: $marker-color;
+      margin-top: 3px;
+    }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -48,5 +48,6 @@ $on-laptop:        1000px;
 @import
         "base",
         "layout",
-        "syntax-highlighting"
+        "syntax-highlighting",
+        "sortable"
 ;

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ layout: default
   of the potential for breaking many sites. Still, manual upgrade options should be offered to move 
   from one PHP version to another, and automatic updates at the patch level (0.0.X) should be provided.</p>
 
-  <table>
+  <table data-sortable>
     <thead>
       <tr>
         <th>Host</th>
@@ -54,7 +54,7 @@ layout: default
 
   <h2>Custom Hosting</h2>
 
-  <table>
+  <table data-sortable>
     <thead>
       <tr>
         <th>Host</th>
@@ -85,7 +85,7 @@ layout: default
 
   <h2>Linux Distributions</h2>
 
-  <table>
+  <table data-sortable>
     <thead>
       <tr>
         <th>Distribution</th>


### PR DESCRIPTION
Useful when trying to see what hosts use a specific versions range.

e.g: "my project uses PHP 5.5 and up. what hosts can I use?"
