### PR TITLE
Move App Engine into PaaS. Remove 5.4 reference.

### DIFF
--- a/_data/paas_hosts.yml
+++ b/_data/paas_hosts.yml
@@ -1,3 +1,9 @@
+- name: "Google App Engine"
+  url: "https://cloud.google.com/appengine/"
+  php55: 23
+  default: 5.5.23
+  auto_update: "Yes"
+
 - name: "Heroku"
   url: "https://devcenter.heroku.com/articles/php-support#php-runtimes"
   php55: 28

--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -85,13 +85,6 @@
   default: 5.5.??
   manual_update: "Yes"
 
-- name: "Google App Engine"
-  url: "https://cloud.google.com/appengine/"
-  php54: 35
-  php55: 23
-  default: 5.5.23
-  auto_update: "Yes"
-
 - name: "Heart Internet"
   url: "https://www.heartinternet.uk/web-hosting"
   php52: 17


### PR DESCRIPTION
Latest version validated 2015-08-31 with SDK 1.9.25