### PR TITLE
Update PHP versions for Debian 7 and 8

### DIFF
--- a/_data/linux_distros.yml
+++ b/_data/linux_distros.yml
@@ -1,8 +1,8 @@
 - name: "Debian 8 (Jessie)"
-  default: 5.6.7
+  default: 5.6.12
 
 - name: "Debian 7 (Wheezy)"
-  default: 5.4.4
+  default: 5.4.44
 
 - name: "Debian 6 (Squeeze)"
   default: 5.3.3


### PR DESCRIPTION
These have been updated to the latest versions recently. See https://packages.debian.org/jessie/php5