### PR TITLE
Added details of iPage (shared host)

### DIFF
--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -143,6 +143,14 @@
   php54: ??
   default: 5.4.??
 
+- name: "iPage"
+  url: "https://www.ipage.com/"
+  php52: 17
+  php53: 13
+  php54: ??
+  php55: 1
+  default: 5.3.13
+
 - name: "Krystal"
   url: "https://krystal.co.uk/"
   php52: 17


### PR DESCRIPTION
As the title says - added details of iPage (a shared host). 

Answers came from from a support agent. 

No option to use 5.4 apparently.