### PR TITLE
Talked with bluehost support, updated PHP offerings

### DIFF
--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -35,10 +35,9 @@
 
 - name: "Bluehost"
   url: "http://www.bluehost.com/shared"
-  php52: 17
-  php53: 0
-  php54: 40
-  default: 5.2.17
+  php54: 0
+  php56: 0
+  default: 5.4.0
 
 - name: "Crucial (Split Shared)"
   url: http://www.crucialwebhost.com/hosting/split-shared/

--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -35,9 +35,9 @@
 
 - name: "Bluehost"
   url: "http://www.bluehost.com/shared"
-  php54: 0
+  php54: 24
   php56: 0
-  default: 5.4.0
+  default: 5.4.24
 
 - name: "Crucial (Split Shared)"
   url: http://www.crucialwebhost.com/hosting/split-shared/

--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -36,7 +36,7 @@
 - name: "Bluehost"
   url: "http://www.bluehost.com/shared"
   php54: 24
-  php56: 0
+  php56: 11
   default: 5.4.24
 
 - name: "Crucial (Split Shared)"


### PR DESCRIPTION
I'm not sure on the exact point release of these, but you can go to http://bluehost.com/demo > cpanel > php config to see the options they provide. Legacy accounts may fall back to php 5.2, but new accounts are made with php 5.4, and they don't give you a 5.2 option.

Oddly it looks like they support php 5.4 and 5.6 only, no 5.5.