### PR TITLE
update laravel forge to show RC7 for php 7

### DIFF
--- a/_data/paas_hosts.yml
+++ b/_data/paas_hosts.yml
@@ -24,7 +24,7 @@
 - name: "Laravel Forge"
   url: "https://forge.laravel.com/"
   php56: 12
-  php70: RC2
+  php70: RC7
   default: 5.6.12
   auto_update: "Yes"
 


### PR DESCRIPTION
forge uses ```http://ppa.launchpad.net/ondrej/php-7.0/ubuntu trusty main``` so it should always be up to date with the latest release