### PR TITLE
For final hosts' versions, the version should be displayed as 7.0.x

### DIFF
--- a/php-7.html
+++ b/php-7.html
@@ -36,7 +36,7 @@ layout: default
         <tr>
           {% if host.php70 %}
           <td class="host-name"><a href="{{ host.url }}">{{ host.name }}</a></td>
-          <td class="host-info good-php">{{ host.php70 }}</td>
+          <td class="host-info good-php">7.0.{{ host.php70 }}</td>
           {% endif %}
         </tr>
       {% endfor %}


### PR DESCRIPTION
Currently it displays `0` as the version string, which is confusing (like, what does the zero mean?) for most visitors. Instead, it should display the full version number, which for a while will be `7.0.x`.