### PR TITLE
Fixed the link on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ layout: index
 <div class="homepage-faq grid-item-image">
   <h2>FAQ</h2>
   <h3>Where do you get the data from?</h3>
-    <p>This is a community managed project. People send the versions in <a href="https://github.com/philsturgeon/phpversions.info/tree/gh-pages/_data">via GitHub</a>. We've had a few hosting company employees sending in updates as they deploy them, which is cool.</p>
+    <p>This is a community managed project. People send the versions in <a href="https://github.com/philsturgeon/phpversions.info">via GitHub</a>. We've had a few hosting company employees sending in updates as they deploy them, which is cool.</p>
   <h3>Any plans to automate this?</h3>
     <p><a href="https://github.com/philsturgeon/phpversions.info/issues/82">Yeah loads</a>, but for now we still rely on humans.</p>
   <h3>How do I contribute?</h3>


### PR DESCRIPTION
Replaced the faulty link; https://github.com/philsturgeon/phpversions.info/tree/gh-pages/_data to a direct link to the Github project homepage