### PR TITLE
Onlime discontinues legacy PHP 5.4

### DIFF
--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -278,11 +278,10 @@
 
 - name: "Onlime Webhosting"
   url: "https://www.onlime.ch/"
-  php54: 45
   php55: 30
   php56: 16
   php70: 0
-  default: 5.6.15
+  default: 5.6.16
   manual_update: "Yes (Minor)"
   auto_update: "Yes (Patch)"
 


### PR DESCRIPTION
Die 5.4, die! Now as PHP7 heaven is on earth.