### PR TITLE
Update Monarobase PHP versions

### DIFF
--- a/_data/shared_hosts.yml
+++ b/_data/shared_hosts.yml
@@ -244,9 +244,9 @@
   php53: 29
   php54: 45
   php55: 30
-  php56: 15
-  php70: RC7
-  default: 5.6.15
+  php56: 16
+  php70: 0
+  default: 5.6.16
   manual_update: "Yes"
   auto_update: "Yes"
 


### PR DESCRIPTION
We've updated PHP 7 to the latest stable version.