### PR TITLE
Dreamhost Update

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -264,24 +264,18 @@
     name: Dreamhost
     url: 'http://www.dreamhost.com/hosting/shared/'
     type: shared
-    php56: 0
-    default: 5.4.20
+    default: 5.6.10
     versions:
-        53:
-            phpinfo: null
-            patch: 27
-            version: 5.3.27
-            semver: 5.3.27
-        54:
-            phpinfo: null
-            patch: 20
-            version: 5.4.20
-            semver: 5.4.20
         55:
             phpinfo: null
-            patch: 17
-            version: 5.5.17
-            semver: 5.5.17
+            patch: 26
+            version: 5.5.26
+            semver: 5.5.26
+        56:
+            phpinfo: null
+            patch: 10
+            version: 5.6.10
+            semver: 5.6.10
 -
     name: fortrabbit
     url: 'http://www.fortrabbit.com/'


### PR DESCRIPTION
Dreamhost EOL'd PHP 5.3 and 5.4 on January 26, 2016. They are no longer available through their panel or supported.

Added latest PHP 5.5 and 5.6 versions from shared hosting, screenshots for verification:

http://i.imgur.com/nz6TB1i.png
http://i.imgur.com/FVk0CoG.png
http://i.imgur.com/SJrGyyI.png