### PR TITLE
Updates versions for cyon.ch and adds phpinfo URLs

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -200,23 +200,23 @@
     name: cyon
     url: 'https://www.cyon.ch'
     type: shared
-    default: 5.6.17
+    default: 5.6.18
     versions:
         55:
-            phpinfo: null
-            patch: 31
-            version: 5.5.31
-            semver: 5.5.31
+            phpinfo: 'https://phpversions.cyon.info/55/'
+            patch: 32
+            version: 5.5.32
+            semver: 5.5.32
         56:
-            phpinfo: null
-            patch: 17
-            version: 5.6.17
-            semver: 5.6.17
+            phpinfo: 'https://phpversions.cyon.info/56/'
+            patch: 18
+            version: 5.6.18
+            semver: 5.6.18
         70:
-            phpinfo: null
-            patch: 2
-            version: 7.0.2
-            semver: 7.0.2
+            phpinfo: 'https://phpversions.cyon.info/70/'
+            patch: 3
+            version: 7.0.3
+            semver: 7.0.3
 -
     name: DiPHOST
     url: 'http://www.diphost.ru/'


### PR DESCRIPTION
We do provide a phpinfo URL for the standard version, if that's something you're planning to automate :) https://phpversions.cyon.info/