### PR TITLE
Update the default version on heroku

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -392,7 +392,7 @@
     name: Heroku
     url: 'https://devcenter.heroku.com/articles/php-support#php-runtimes'
     type: paas
-    default: 5.6.17
+    default: 5.6.18
     versions:
         55:
             phpinfo: null


### PR DESCRIPTION
The way they select the default version will always give them the latest 5.x version available on their system (they select versions matching ``^5.5.17`` by default, according to the composer constraint system)