### PR TITLE
Updating Dreamhost PHP 7

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -292,6 +292,11 @@
             patch: 10
             version: 5.6.10
             semver: 5.6.10
+        70:
+            phpinfo: null
+            patch: 2
+            version: 7.0.2
+            sever: 7.0.2
 -
     name: fortrabbit
     url: 'http://www.fortrabbit.com/'


### PR DESCRIPTION
Dreamhost now offer PHP 7.0.2 on CGI and FastCGI