### PR TITLE
[LiquidWeb] Managed servers offered too

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -858,6 +858,37 @@
             version: '5.5.??'
             semver: '5.5.??'
 -
+    name: Liquidweb
+    url: 'http://www.liquidweb.com/?RID=phpversions'
+    type: managed
+    default: 55
+    versions:
+        53:
+            phpinfo: null
+            patch: '??'
+            version: '5.3.??'
+            semver: '5.3.??'
+        54:
+            phpinfo: null
+            patch: '??'
+            version: '5.4.??'
+            semver: '5.4.??'
+        55:
+            phpinfo: null
+            patch: '??'
+            version: '5.5.??'
+            semver: '5.5.??'
+        56:
+            phpinfo: null
+            patch: '??'
+            version: '5.6.??'
+            semver: '5.6.??'
+        70:
+            phpinfo: null
+            patch: '??'
+            version: '7.0.??'
+            semver: '7.0.??'
+-
     name: Lunarpages
     url: 'https://support.lunarpages.com/knowledge_bases/article/326?fallback=true'
     type: shared

--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -865,29 +865,29 @@
     versions:
         53:
             phpinfo: null
-            patch: '??'
-            version: '5.3.??'
-            semver: '5.3.??'
+            patch: '29'
+            version: '5.3.29'
+            semver: '5.3.29'
         54:
             phpinfo: null
-            patch: '??'
-            version: '5.4.??'
-            semver: '5.4.??'
+            patch: '45'
+            version: '5.4.45'
+            semver: '5.4.45'
         55:
             phpinfo: null
-            patch: '??'
-            version: '5.5.??'
-            semver: '5.5.??'
+            patch: '34'
+            version: '5.5.34'
+            semver: '5.5.34'
         56:
             phpinfo: null
-            patch: '??'
-            version: '5.6.??'
-            semver: '5.6.??'
+            patch: '20'
+            version: '5.6.20'
+            semver: '5.6.20'
         70:
             phpinfo: null
-            patch: '??'
-            version: '7.0.??'
-            semver: '7.0.??'
+            patch: '5'
+            version: '7.0.5'
+            semver: '7.0.5'
 -
     name: Lunarpages
     url: 'https://support.lunarpages.com/knowledge_bases/article/326?fallback=true'


### PR DESCRIPTION
LiquidWeb also offers Managed servers in addition to Shared servers.

With Managed Server [dedi or vps] the end user has much more freedom to configure the server as they'd like, unlike shared servers. So depending on the version of EasyApache they are using, on the server, they should expect access to PHP 5.3 - 7.0. There are no PHP 7.0 enabled Shared servers yet, but it's certainly offered on Managed servers.

If you're not familiar with EasyApache:
On EasyApache3 they can have a single version of 5.3.x - 5.6.x.
On EasyApache4 then can have either multiple or a single PHP version choosing between 5.4.x - 7.0.x.

Please let me know if this needs to be formatted any differently for the purposes of this site. Thanks!