### PR TITLE
[LiquidWeb] Missing a version of PHP

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -857,6 +857,11 @@
             patch: '??'
             version: '5.5.??'
             semver: '5.5.??'
+        56:
+            phpinfo: null
+            patch: '??'
+            version: '5.6.??'
+            semver: '5.6.??'
 -
     name: Lunarpages
     url: 'https://support.lunarpages.com/knowledge_bases/article/326?fallback=true'


### PR DESCRIPTION
LiquidWeb does have shared servers which offer PHP 5.6.xx.