### PR TITLE
Add Ubuntu 16.04 LTS in Operating Systems

### DIFF
--- a/_data/operating_systems.yml
+++ b/_data/operating_systems.yml
@@ -113,3 +113,11 @@
     version: 5.6.11+dfsg-1ubuntu3.1
     semver: 5.6.11
     patch: 11
+-
+    name: 'Ubuntu 16.04 LTS (Xenial)'
+    family: linux
+    distro: ubuntu
+    package_url: 'http://packages.ubuntu.com/xenial/php/php7.0'
+    version: 7.0.4-7ubuntu2
+    semver: 7.0.4
+    patch: 4

--- a/_data/operating_systems.yml
+++ b/_data/operating_systems.yml
@@ -101,7 +101,7 @@
     name: 'Ubuntu 15.04 (Vivid)'
     family: linux
     distro: ubuntu
-    package_url: 'http://packages.ubuntu.com/vivid/php/php5'
+    package_url: null
     version: 5.6.4+dfsg-4ubuntu6.4
     semver: 5.6.4
     patch: 4


### PR DESCRIPTION
Introducing PHP 7.0.4 in Ubuntu 16.04

Ubuntu 15.04 updates are no longer maintained, so checking at `http://packages.ubuntu.com/vivid/php/php5` returns error