### PR TITLE
Update Hetzner.de in hosts.yaml -> add phpinof(s)

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -522,25 +522,35 @@
     default: 53
     versions:
         52:
-            phpinfo: null
+            phpinfo: 'http://www.testen.de/info.php52'
             patch: 17
             version: 5.2.17
             semver: 5.2.17
         53:
-            phpinfo: null
+            phpinfo: 'http://www.testen.de/info.php53'
             patch: 29
             version: 5.3.29
             semver: 5.3.29
         54:
-            phpinfo: null
-            patch: 36
-            version: 5.4.36
-            semver: 5.4.36
+            phpinfo: 'http://www.testen.de/info.php54'
+            patch: 45
+            version: 5.4.45
+            semver: 5.4.45
         55:
-            phpinfo: null
-            patch: 20
-            version: 5.5.20
-            semver: 5.5.20
+            phpinfo: 'http://www.testen.de/info.php55'
+            patch: 35
+            version: 5.5.35
+            semver: 5.5.35
+        56:
+            phpinfo: 'http://www.testen.de/info.php56'
+            patch: 21
+            version: 5.6.21
+            semver: 5.6.21
+        70:
+            phpinfo: 'http://www.testen.de/info.php70'
+            patch: 6
+            version: 7.0.6
+            semver: 7.0.6
 -
     name: Hostek
     url: 'https://hostek.com/'


### PR DESCRIPTION
Updated all the versions at German shared webhost Hetzner.de
I don't know what the current default php version is, you can either set it in their dashboard or just use version specific filenames (i.e. index.php52 for php 5.2 series and index.php70 for php 7.0 series)
They do claim to still support php4, but a) noone shold use that on a public webhost and b) their phpinfo for that doesn't even work.

(All phpinfos are available at testen.de => That translates to testing.de)