### PR TITLE
Updates Uberspace-PHP-Version

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1622,6 +1622,11 @@
             patch: 12
             version: 5.6.12
             semver: 5.6.12
+        70:
+            phpinfo: null
+            patch: 6
+            version: 7.0.6
+            semver: 7.0.6
 -
     name: 'Unleashed Technologies'
     url: 'https://www.unleashed-technologies.com/services/web-hosting'


### PR DESCRIPTION
Uberspace supports PHP7 from the beginning on. This adds their Current PHP7-Default