### PR TITLE
Switch Platform.sh to automated version checks

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1239,25 +1239,13 @@
     default: 54
     versions:
         54:
-            phpinfo: null
-            patch: 45
-            version: 5.4.45
-            semver: 5.4.45
+            phpinfo: http://php54---master-hqsu3e3xomwtm.eu.platform.sh/
         55:
-            phpinfo: null
-            patch: 30
-            version: 5.5.30
-            semver: 5.5.30
+            phpinfo: http://php55---master-hqsu3e3xomwtm.eu.platform.sh/
         56:
-            phpinfo: null
-            patch: 14
-            version: 5.6.14
-            semver: 5.6.14
+            phpinfo: http://php56---master-hqsu3e3xomwtm.eu.platform.sh/
         70:
-            phpinfo: null
-            patch: 0
-            version: 7.0.0
-            sever: 7.0.0
+            phpinfo: http://php70---master-hqsu3e3xomwtm.eu.platform.sh/
 -
     name: 'Rackspace (Cloud Sites)'
     url: 'http://www.rackspace.com/cloud/sites'


### PR DESCRIPTION
It's unclear if we need to keep the major/minor lines if we have a phpinfo URL.  It seems redundant since the URL should be providing that data.  Let me know if I should restore them, but I think this will work? :smile:

Those environments are rebuilt manually, but we'll handle kicking them when patch releases are updated.