### PR TITLE
Adds phpinfo-files for Uberspace.de

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1609,22 +1609,22 @@
             version: 5.3.29
             semver: 5.3.29
         54:
-            phpinfo: null
+            phpinfo: 'https://php.ug/php5.4'
             patch: 44
             version: 5.4.44
             semver: 5.4.44
         55:
-            phpinfo: null
+            phpinfo: 'https://php.ug/php5.5'
             patch: 28
             version: 5.5.35
             semver: 5.5.35
         56:
-            phpinfo: null
+            phpinfo: 'https://php.ug/php5.6'
             patch: 12
             version: 5.6.21
             semver: 5.6.21
         70:
-            phpinfo: 'http://php.ug/info.php'
+            phpinfo: 'http://php.ug/php7.0'
             patch: 6
             version: 7.0.6
             semver: 7.0.6


### PR DESCRIPTION
After checking with the folks from Uberspace I created the necessary phpinfo-files to automatically check the most current PHP-Versions. Default is still PHP 5.6 but every user can change that within seconds to PHP 7