### PR TITLE
Adding Cloudways PaaS provider

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1904,3 +1904,19 @@
             patch: '4'
             version: 7.0.4
             semver: 7.0.4
+-
+    name: 'Cloudways'
+    url: 'http://www.cloudways.com/en/'
+    type: pass
+    default: 56
+    versions:
+        56:
+            phpinfo: null
+            patch: 19
+            version: 5.6.19
+            semver: 5.6.19    
+        70:
+            phpinfo: null
+            patch: 7
+            version: 7.0.7
+            semver: 7.0.7


### PR DESCRIPTION
Cloudways is a Managed Cloud Hosting Platform for PHP based applications like PHP stack, WordPress, Magento, Prestashop, Joomla, Drupal etc.
- It is not focused on WordPress only. If a customer has a store on Magento, while a blog on WordPress, he can run both of them by using a single server.
- We provide users to choose a server from four different cloud infrastructures like DigitalOcean, Vultr, Amazon and Google Cloud. Yes, it is extremely easy to host on these infrastructures when you are with Cloudways.
-  What makes us different? Our customized, advanced caching stack technology, which includes the likes  of NGINX, Varnish, Memcached, Apache and Redis, that boosts page load performance. We promise a Page-load time of 50% less than the industry, owing to our optimized stack.
- Prices are Pay as You Go, with multiple pay options and plans suited to your needs.
- Improved UI and UX design. You can check out our feedback from different testers.