### PR TITLE
Add PHP 7.0.2 to MediaTemple GS + timestamp

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -963,6 +963,12 @@
             patch: 21
             version: 5.5.21
             semver: 5.5.21
+        70:
+            phpinfo: null
+            patch: 2
+            version: 7.0.2
+            semver: 7.0.2
+    last_scanned_at: '2016-06-27T17:23:00+0000'
 -
     name: 'Microsoft Azure Web App'
     url: 'http://azure.microsoft.com/en-us/services/websites'


### PR DESCRIPTION
Added PHP 7.0.2, based on the information at https://mediatemple.net/webhosting/shared/.

Also added the last_scanned_at timestamp.

![Image](https://screencap.xyz/VXOQmtURzG.png)
