### PR TITLE
Updated iClickAndHost versions as of 206/07/29

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -721,19 +721,29 @@
             semver: 5.3.29
         54:
             phpinfo: null
-            patch: 39
-            version: 5.4.39
-            semver: 5.4.39
+            patch: 45
+            version: 5.4.45
+            semver: 5.4.45
         55:
             phpinfo: null
-            patch: 23
-            version: 5.5.23
-            semver: 5.5.23
+            patch: 37
+            version: 5.5.37
+            semver: 5.5.37
         56:
             phpinfo: null
-            patch: 16
-            version: 5.6.16
-            semver: 5.6.16
+            patch: 23
+            version: 5.6.23
+            semver: 5.6.23
+        70:
+            phpinfo: null
+            patch: 8
+            version: 7.0.8
+            semver: 7.0.8
+        71:
+            phpinfo: null
+            patch: 0
+            version: 7.1.0alpha3
+            semver: 7.1.0alpha3
 -
     name: 'InMotion Hosting'
     url: 'http://www.inmotionhosting.com/'


### PR DESCRIPTION
I'm not sure if 5.6 is still the default or not, but I've updated all the versions they offer on Shared Hosting.