### PR TITLE
PHP 5.6 is now the default PHP version at Combell

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -170,7 +170,7 @@
     name: Combell
     url: 'http://www.combell.com/en/hosting/web-hosting'
     type: shared
-    default: 55
+    default: 56
     versions:
         52:
             phpinfo: 'http://php52.webhosting.be/phpinfo.php'


### PR DESCRIPTION
We decided that 5.6 is the way to go.