### PR TITLE
add phpinfo urls for amazee.io

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -82,11 +82,13 @@
             patch: 25
             version: 5.6.25
             semver: 5.6.25
+            phpinfo: http://php56-phpinfo.amazee.io.php_56.test2.compact.amazee.io/
         70:
             phpinfo: null
             patch: 10
             version: 7.0.10
             semver: 7.0.10
+            phpinfo: http://php70-phpinfo.amazee.io.php_70.test2.compact.amazee.io/
 -
     name: Aruba.it
     url: 'http://hosting.aruba.it/'


### PR DESCRIPTION
Team agreed that the phpinfo(1) would be just fine having publicly exposed.