### PR TITLE
Add 7.1 version for OVH

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1344,7 +1344,7 @@
             phpinfo: 'http://xncassep.cluster014.ovh.net/phpinfo.php'
             version: 7.1.0
             patch: 0
-            semver 7.1.0
+            semver: 7.1.0
     last_scanned_at: '2016-09-29T22:05:40+0000'
 -
     name: 'Pagoda Box'

--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1340,6 +1340,11 @@
             version: 7.0.10
             patch: 10
             semver: 7.0.10
+        71:
+            phpinfo: 'http://xncassep.cluster014.ovh.net/phpinfo.php'
+            version: 7.1.0
+            patch: 0
+            semver 7.1.0
     last_scanned_at: '2016-09-29T22:05:40+0000'
 -
     name: 'Pagoda Box'


### PR DESCRIPTION
We have just released the PHP 7.1 RC version on ovh hosting offers