### PR TITLE
Add openSUSE to the list of distributions, update Ubuntu

### DIFF
--- a/_data/operating_systems.yml
+++ b/_data/operating_systems.yml
@@ -124,3 +124,27 @@
     version: 7.0.8-0ubuntu0.16.04.2
     semver: 7.0.8
     patch: 8
+-
+    name: 'Ubuntu 16.10 (Yakkety)'
+    family: linux
+    distro: ubuntu
+    package_url: 'http://packages.ubuntu.com/yakkety/php/php7.0'
+    version: 7.0.8-3ubuntu3
+    semver: 7.0.8
+    patch: 8
+-
+    name: 'ppenSUSE Tumbleweed'
+    family: linux
+    distro: opensuse
+    package_url: 'https://software.opensuse.org/package/php7'
+    version: 7.0.12
+    semver: 7.0.12
+    patch: 12
+-
+    name: 'ppenSUSE Leap 42.1'
+    family: linux
+    distro: opensuse
+    package_url: 'https://software.opensuse.org/package/php5'
+    version: 5.5.14
+    semver: 5.5.14
+    patch: 14


### PR DESCRIPTION
Added openSUSE Tumbleweed (rolling release) and Leap 42.1
Updated Ubuntu by adding the 16,10 (Yakkety) release