### PR TITLE
fix openSUSE name, disable package url

### DIFF
--- a/_data/operating_systems.yml
+++ b/_data/operating_systems.yml
@@ -133,18 +133,18 @@
     semver: 7.0.8
     patch: 8
 -
-    name: 'ppenSUSE Tumbleweed'
+    name: 'openSUSE Tumbleweed'
     family: linux
     distro: opensuse
-    package_url: 'https://software.opensuse.org/package/php7'
+    #package_url: 'https://software.opensuse.org/package/php7'
     version: 7.0.12
     semver: 7.0.12
     patch: 12
 -
-    name: 'ppenSUSE Leap 42.1'
+    name: 'openSUSE Leap 42.1'
     family: linux
     distro: opensuse
-    package_url: 'https://software.opensuse.org/package/php5'
+    #package_url: 'https://software.opensuse.org/package/php5'
     version: 5.5.14
     semver: 5.5.14
     patch: 14


### PR DESCRIPTION
since there is no common element on package page linked, and their
official api requires a http authentication header, i see no way to
cleanly enable auto updating for this operating system