### PR TITLE
Use <abbr> to hide long version numbers (fixes #296)

### DIFF
--- a/_plugins/version.rb
+++ b/_plugins/version.rb
@@ -1,0 +1,13 @@
+module Jekyll
+  module FormatVersionFilter
+    def format_version(info)
+      return "-" if not info
+
+      return info['semver'] if info['semver'] == info['version']
+
+      return '<abbr title="%s">%s</abbr>' % [info['version'], info['semver']]
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::FormatVersionFilter)

--- a/managed-hosting.html
+++ b/managed-hosting.html
@@ -30,22 +30,12 @@ layout: default
                     <td class="host-info" data-last-scanned="{{ host.last_scanned_at }}">
                         <i class="fa fa-times"></i>
                     </td>
-                    <td class="host-info version">
-                        {% if host.versions[71] %}{{ host.versions[71].version }}{% else %}-{% endif %}
-                    </td>
-                    <td class="host-info version">
-                        {% if host.versions[70] %}{{ host.versions[70].version }}{% else %}-{% endif %}
-                    </td>
-                    <td class="host-info version">
-                        {% if host.versions[56] %}{{ host.versions[56].version }}{% else %}-{% endif %}
-                    </td>
-                    <td class="host-info version">
-                        {% if host.versions[55] %}{{ host.versions[55].version }}{% else %}-{% endif %}
-                    </td>
-                    <td class="host-info version">
-                        {% if host.versions[54] %}{{ host.versions[54].version }}{% else %}-{% endif %}
-                    </td>
-                    <td class="host-info version">{% if host.default %}{{ host.versions[host.default].version }}{% else %}<em>???</em>{% endif %}</td>
+                    <td class="host-info version">{{ host.versions[71] | format_version }}</td>
+                    <td class="host-info version">{{ host.versions[70] | format_version }}</td>
+                    <td class="host-info version">{{ host.versions[56] | format_version }}</td>
+                    <td class="host-info version">{{ host.versions[55] | format_version }}</td>
+                    <td class="host-info version">{{ host.versions[54] | format_version }}</td>
+                    <td class="host-info version">{% if host.default %}{{ host.versions[host.default] | format_version }}{% else %}<em>???</em>{% endif %}</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/new-and-shiny.html
+++ b/new-and-shiny.html
@@ -29,7 +29,7 @@ layout: default
           <td class="host-info" data-last-scanned="{{ host.last_scanned_at }}">
               <i class="fa fa-times"></i>
           </td>
-          <td class="host-info version">{{ host.versions[71].version }}</td>
+          <td class="host-info version">{{ host.versions[71] | format_version }}</td>
         </tr>
         {% endif %}
       {% endfor %}

--- a/operating-systems.html
+++ b/operating-systems.html
@@ -29,7 +29,7 @@ layout: default
         <tr>
           <td class="host-name">{{ system.name }}</td>
           <td class="host-info">{{ system.family }}</td>
-          <td class="host-info version">{{ system.version }}</td>
+          <td class="host-info version">{{ system | format_version }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/paas-hosting.html
+++ b/paas-hosting.html
@@ -31,22 +31,12 @@ layout: default
                 <td class="host-info" data-last-scanned="{{ host.last_scanned_at }}">
                     <i class="fa fa-times"></i>
                 </td>
-                <td class="host-info version">
-                    {% if host.versions[71] %}{{ host.versions[71].version }}{% else %}-{% endif %}
-                </td>
-                <td class="host-info version">
-                    {% if host.versions[70] %}{{ host.versions[70].version }}{% else %}-{% endif %}
-                </td>
-                <td class="host-info version">
-                    {% if host.versions[56] %}{{ host.versions[56].version }}{% else %}-{% endif %}
-                </td>
-                <td class="host-info version">
-                    {% if host.versions[55] %}{{ host.versions[55].version }}{% else %}-{% endif %}
-                </td>
-                <td class="host-info version">
-                    {% if host.versions[54] %}{{ host.versions[54].version }}{% else %}-{% endif %}
-                </td>
-                <td class="host-info version">{% if host.default %}{{ host.versions[host.default].version }}{% else %}<em>???</em>{% endif %}</td>
+                <td class="host-info version">{{ host.versions[71] | format_version }}</td>
+                <td class="host-info version">{{ host.versions[70] | format_version }}</td>
+                <td class="host-info version">{{ host.versions[56] | format_version }}</td>
+                <td class="host-info version">{{ host.versions[55] | format_version }}</td>
+                <td class="host-info version">{{ host.versions[54] | format_version }}</td>
+                <td class="host-info version">{% if host.default %}{{ host.versions[host.default] | format_version }}{% else %}<em>???</em>{% endif %}</td>
               </tr>
             {% endfor %}
             </tbody>

--- a/shared-hosting.html
+++ b/shared-hosting.html
@@ -30,22 +30,12 @@ layout: default
             <td class="host-info" data-last-scanned="{{ host.last_scanned_at }}" data-value="{{ host.last_scanned_at }}">
                 <i class="fa fa-times"></i>
             </td>
-            <td class="host-info version">
-                {% if host.versions[71] %}{{ host.versions[71].version }}{% else %}-{% endif %}
-            </td>
-            <td class="host-info version">
-                {% if host.versions[70] %}{{ host.versions[70].version }}{% else %}-{% endif %}
-            </td>
-            <td class="host-info version">
-                {% if host.versions[56] %}{{ host.versions[56].version }}{% else %}-{% endif %}
-            </td>
-            <td class="host-info version">
-                {% if host.versions[55] %}{{ host.versions[55].version }}{% else %}-{% endif %}
-            </td>
-            <td class="host-info version">
-                {% if host.versions[54] %}{{ host.versions[54].version }}{% else %}-{% endif %}
-            </td>
-            <td class="host-info version">{% if host.default %}{{ host.versions[host.default].version }}{% else %}<em>???</em>{% endif %}</td>
+            <td class="host-info version">{{ host.versions[71] | format_version }}</td>
+            <td class="host-info version">{{ host.versions[70] | format_version }}</td>
+            <td class="host-info version">{{ host.versions[56] | format_version }}</td>
+            <td class="host-info version">{{ host.versions[55] | format_version }}</td>
+            <td class="host-info version">{{ host.versions[54] | format_version }}</td>
+            <td class="host-info version">{% if host.default %}{{ host.versions[host.default] | format_version }}{% else %}<em>???</em>{% endif %}</td>
           </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
This implements a new filter to reduce code duplication.  The filter takes an
array of host data and returns one of three potential results:

 - A placeholder "-" if the host doesn't support the given version
 - The semver, if it's identical to the version number
 - An <abbr> which shows the longer version number when you hover over it