### PR TITLE
Remove unused 5.3 column header

### DIFF
--- a/paas-hosting.html
+++ b/paas-hosting.html
@@ -19,7 +19,6 @@ layout: default
                 <th>5.6</th>
                 <th>5.5</th>
                 <th>5.4</th>
-                <th>5.3</th>
                 <th>Default</th>
               </tr>
             </thead>


### PR DESCRIPTION
Fixes this bug:  
![image](https://cloud.githubusercontent.com/assets/202034/20064838/12e1e0a0-a4da-11e6-80c3-2cde44e5f66b.png)

