### PR TITLE
Updated versions for Onlime

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1284,19 +1284,19 @@
     versions:
         56:
             phpinfo: 'https://php56.onlime.ch/'
-            patch: 26
-            version: 5.6.26
-            semver: 5.6.26
+            patch: 28
+            version: 5.6.28
+            semver: 5.6.28
         70:
             phpinfo: 'https://php70.onlime.ch/'
-            patch: 11
-            version: 7.0.11
-            semver: 7.0.11
+            patch: 13
+            version: 7.0.13
+            semver: 7.0.13
         71:
             phpinfo: 'https://php71.onlime.ch/'
             patch: 0
-            version: 7.1.0RC3
-            semver: 7.1.0-RC3
+            version: 7.1.0RC6
+            semver: 7.1.0-RC6
     last_scanned_at: '2016-09-29T22:05:37+0000'
 -
     name: 'OpenShift Online'


### PR DESCRIPTION
somehow, the php71 version is not getting correctly pulled from phpinfo. For Onlime, it still listed 7.1.0RC3 instead of 7.1.0RC6.
Please check. Thx.