### PR TITLE
Update for Rackspace Cloud Sites

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1443,6 +1443,11 @@
             patch: 17
             version: 5.6.17-0+deb8u1
             semver: 5.6.17
+        70:
+            phpinfo: null
+            patch: 12
+            version: 7.0.12-1~dotdeb+8.1
+            semver: 7.0.12
 -
     name: Register365
     url: 'https://www.register365.com/web-hosting/'


### PR DESCRIPTION
Rackspace Cloud Sites now offers 7.0.12 as an option. 5.6 is still default.