### PR TITLE
Update Liquid Web related items

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1020,31 +1020,31 @@
     type: managed
     default: 55
     versions:
-        53:
-            phpinfo: null
-            patch: '29'
-            version: 5.3.29
-            semver: 5.3.29
         54:
             phpinfo: null
             patch: '45'
-            version: 5.4.45
+            version: 5.4.45-15.15.3.cpanel
             semver: 5.4.45
         55:
             phpinfo: null
-            patch: '34'
-            version: 5.5.34
-            semver: 5.5.34
+            patch: '38'
+            version: 5.5.38-1.1.2.cpanel
+            semver: 5.5.38
         56:
             phpinfo: null
-            patch: '20'
-            version: 5.6.20
-            semver: 5.6.20
+            patch: '28'
+            version: 5.6.28-1.1.1.cpanel
+            semver: 5.6.28
         70:
             phpinfo: null
-            patch: '5'
-            version: 7.0.5
-            semver: 7.0.5
+            patch: '13'
+            version: 7.0.13-1.1.1.cpanel
+            semver: 7.0.13
+        71:
+            phpinfo: null
+            patch: '0'
+            version: 7.1.0-8.RC6.8.1.cpanel
+            semver: 7.1.0
 -
     name: 'Liquid Web Cloud Sites'
     url: 'https://www.liquidweb.com/cloudsites/'

--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -296,6 +296,37 @@
             semver: 7.1.0-RC2.0
     last_scanned_at: '2016-09-29T22:05:15+0000'
 -
+    name: Deluxe Hosting
+    url: 'http://deluxehosting.com/'
+    type: shared
+    default: 55
+    versions:
+        52:
+            phpinfo: null
+            patch: '??'
+            version: '5.2.??'
+            semver: '5.2.??'
+        53:
+            phpinfo: null
+            patch: '29'
+            version: 5.3.29
+            semver: 5.3.29
+        54:
+            phpinfo: null
+            patch: '45'
+            version: 5.4.45
+            semver: 5.4.45
+        55:
+            phpinfo: null
+            patch: '34'
+            version: 5.5.34
+            semver: 5.5.34
+        56:
+            phpinfo: null
+            patch: '20'
+            version: 5.6.20
+            semver: 5.6.20
+-
     name: DiPHOST
     url: 'http://www.diphost.ru/'
     type: shared
@@ -984,39 +1015,8 @@
             version: 7.0.4
             semver: 7.0.4
 -
-    name: Liquidweb
-    url: 'http://www.liquidweb.com/?RID=phpversions'
-    type: shared
-    default: 55
-    versions:
-        52:
-            phpinfo: null
-            patch: '??'
-            version: '5.2.??'
-            semver: '5.2.??'
-        53:
-            phpinfo: null
-            patch: '29'
-            version: 5.3.29
-            semver: 5.3.29
-        54:
-            phpinfo: null
-            patch: '45'
-            version: 5.4.45
-            semver: 5.4.45
-        55:
-            phpinfo: null
-            patch: '34'
-            version: 5.5.34
-            semver: 5.5.34
-        56:
-            phpinfo: null
-            patch: '20'
-            version: 5.6.20
-            semver: 5.6.20
--
-    name: Liquidweb
-    url: 'http://www.liquidweb.com/?RID=phpversions'
+    name: Liquid Web
+    url: 'http://www.liquidweb.com/'
     type: managed
     default: 55
     versions:
@@ -1045,6 +1045,22 @@
             patch: '5'
             version: 7.0.5
             semver: 7.0.5
+-
+    name: 'Liquid Web Cloud Sites'
+    url: 'https://www.liquidweb.com/cloudsites/'
+    type: paas
+    default: 56
+    versions:
+        56:
+            phpinfo: null
+            patch: 17
+            version: 5.6.17-0+deb8u1
+            semver: 5.6.17
+        70:
+            phpinfo: null
+            patch: 12
+            version: 7.0.12-1~dotdeb+8.1
+            semver: 7.0.12
 -
     name: Lunarpages
     url: 'https://support.lunarpages.com/knowledge_bases/article/326?fallback=true'
@@ -1432,22 +1448,6 @@
             semver: 7.0.7
             version: 7.0.7-1~dotdeb+8.1
     last_scanned_at: '2016-09-29T22:05:45+0000'
--
-    name: 'Rackspace (Cloud Sites)'
-    url: 'http://www.rackspace.com/cloud/sites'
-    type: shared
-    default: 56
-    versions:
-        56:
-            phpinfo: null
-            patch: 17
-            version: 5.6.17-0+deb8u1
-            semver: 5.6.17
-        70:
-            phpinfo: null
-            patch: 12
-            version: 7.0.12-1~dotdeb+8.1
-            semver: 7.0.12
 -
     name: Register365
     url: 'https://www.register365.com/web-hosting/'


### PR DESCRIPTION
Liquid Web no longer offers shared hosting and has actually sold their shared hosting platform to Deluxe: http://deluxehosting.com/faq.html

Liquid Web also now owns Liquid Web Cloud Sites (previously RackSpace Cloud Sites); additionally, the Cloud Sites platform, in its current incarnation, is actually a PaaS rather than a shared.

https://techcrunch.com/2016/08/08/rackspace-sells-cloud-sites-unit-to-liquid-web/
http://www.liquidweb.com/blog/index.php/press-release-liquid-web-acquires-cloud-sites-rackspace/