### PR TITLE
Update Nexcess PHP versions

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1277,7 +1277,7 @@
     name: Nexcess
     url: 'https://www.nexcess.net/'
     type: shared
-    default: 54
+    default: 55
     versions:
         53:
             phpinfo: null
@@ -1291,14 +1291,19 @@
             semver: 5.4.45
         55:
             phpinfo: null
-            patch: 29
-            version: 5.5.29
-            semver: 5.5.29
+            patch: 38
+            version: 5.5.38
+            semver: 5.5.38
         56:
             phpinfo: null
-            patch: 13
-            version: 5.6.13
-            semver: 5.6.13
+            patch: 25
+            version: 5.6.25
+            semver: 5.6.25
+        70:
+            phpinfo: null
+            patch: 12
+            version: 7.0.12
+            semver: 7.0.12
 -
     name: 'Ngage Hosting'
     url: 'https://www.ngagehosting.uk'


### PR DESCRIPTION
We default new accounts to PHP 5.5 now and have updated to newer patch levels of various PHP versions since this was last updated.

We also offer php7.