### PR TITLE
Update Liquid Web Cloud Sites with sync links

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1176,12 +1176,12 @@
     default: 56
     versions:
         56:
-            phpinfo: null
+            phpinfo: 'http://cloudsites-56.liquidweb.name/'
             patch: 24
             version: 5.6.24-0+deb8u1
             semver: 5.6.24
         70:
-            phpinfo: null
+            phpinfo: 'http://cloudsites-70.liquidweb.name/'
             patch: 12
             version: 7.0.12-1~dotdeb+8.1
             semver: 7.0.12


### PR DESCRIPTION
Adding some new sites to the LW related products. I've setup both the 56 and 70 version of Cloud Sites so they can be synced.