### PR TITLE
Add Liquid Web Managed WordPress product (w/sync)

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1197,6 +1197,22 @@
             version: 7.0.12-1~dotdeb+8.1
             semver: 7.0.12
 -
+    name: 'Liquid Web Managed WordPress'
+    url: 'https://www.liquidweb.com/wordpress/'
+    type: paas
+    default: 70
+    versions:
+        56:
+            phpinfo: 'https://managed-wp-56.liquidweb.name/info/index.php'
+            patch: 27
+            version: 5.6.27
+            semver: 5.6.27
+        70:
+            phpinfo: 'https://managed-wp-70.liquidweb.name/info/index.php'
+            patch: 14
+            version: 7.0.14
+            semver: 7.0.14
+-
     name: Lunarpages
     url: 'https://support.lunarpages.com/knowledge_bases/article/326?fallback=true'
     type: shared


### PR DESCRIPTION
Adding some new products/sites from LiquidWeb. I've setup both the 56 and 70 version of Managed WordPress so they can be synced.