### PR TITLE
Rename Ngage Hosting to Kloudhost

### DIFF
--- a/_data/hosts.yml
+++ b/_data/hosts.yml
@@ -1030,6 +1030,42 @@
             version: 7.0.3
             semver: 7.0.3
 -
+    name: Kloudhost
+    url: 'https://www.kloudhost.net'
+    type: shared
+    default: 56
+    versions:
+        53:
+            phpinfo: null
+            patch: 29
+            version: 5.3.29
+            semver: 5.3.29
+        54:
+            phpinfo: null
+            patch: 45
+            version: 5.4.45
+            semver: 5.4.45
+        55:
+            phpinfo: null
+            patch: 38
+            version: 5.5.38
+            semver: 5.5.38
+        56:
+            phpinfo: null
+            patch: 30
+            version: 5.6.30
+            semver: 5.6.30
+        70:
+            phpinfo: null
+            patch: 18
+            version: 7.0.18
+            semver: 7.0.18
+        71:
+            phpinfo: null
+            patch: 4
+            version: 7.1.4
+            semver: 7.1.4
+-
     name: Krystal
     url: 'https://krystal.co.uk/'
     type: shared
@@ -1392,37 +1428,6 @@
             patch: 12
             version: 7.0.12
             semver: 7.0.12
--
-    name: 'Ngage Hosting'
-    url: 'https://www.ngagehosting.uk'
-    type: shared
-    default: 56
-    versions:
-        53:
-            phpinfo: null
-            patch: 29
-            version: 5.3.29
-            semver: 5.3.29
-        54:
-            phpinfo: null
-            patch: 45
-            version: 5.4.45
-            semver: 5.4.45
-        55:
-            phpinfo: null
-            patch: 31
-            version: 5.5.31
-            semver: 5.5.31
-        56:
-            phpinfo: null
-            patch: 17
-            version: 5.6.17
-            semver: 5.6.17
-        70:
-            phpinfo: null
-            patch: 2
-            version: 7.0.2
-            semver: 7.0.2
 -
     name: 'Nucleus BVBA'
     url: 'https://www.nucleus.be/en/webhosting/linux/'


### PR DESCRIPTION
Ngage Hosting has been renamed to Kloudhost (https://www.ngagehosting.uk => https://www.kloudhost.net). I've also updated the available PHP versions.