### PR TITLE
Removing broken CentOS 5 link

### DIFF
--- a/_data/operating_systems.yml
+++ b/_data/operating_systems.yml
@@ -144,11 +144,3 @@
     version: 7.0.14-1
     semver: 7.0.14
     patch: 14
--
-    name: 'Alpine Linux 3.5'
-    family: linux
-    distro: alpine
-    package_url: 'https://pkgs.alpinelinux.org/package/v3.5/main/x86_64/php5'
-    version: 5.6.30-r0
-    semver: 5.6.30
-    patch: 30

--- a/_data/operating_systems.yml
+++ b/_data/operating_systems.yml
@@ -15,14 +15,6 @@
     semver: 5.3.3
     patch: 3
 -
-    name: 'CentOS 5'
-    family: linux
-    distro: centos
-    package_url: 'http://vault.centos.org/centos/5/os/Source/'
-    version: 5.1.6-44.el5_10
-    semver: 5.1.6
-    patch: 6
--
     name: 'Debian 6 (Squeeze)'
     family: linux
     distro: debian

--- a/_data/operating_systems.yml
+++ b/_data/operating_systems.yml
@@ -83,14 +83,6 @@
     semver: 5.6.24
     patch: 24
 -
-    name: 'Ubuntu 12.04 LTS (Precise)'
-    family: linux
-    distro: ubuntu
-    package_url: 'http://packages.ubuntu.com/precise/php/php5'
-    version: 5.3.10-1ubuntu3.25
-    semver: 5.3.10
-    patch: 10
--
     name: 'Ubuntu 14.04 LTS (Trusty)'
     family: linux
     distro: ubuntu


### PR DESCRIPTION
It looks like CentOS deleted the source directory that this file was looking for which was causing a fatal php error.